### PR TITLE
fix(aspire): migrate from deprecated Aspire Workload to NuGet packages

### DIFF
--- a/AspireAppWithAutomation/AspireAppWithAutomation.AppHost/AspireAppWithAutomation.AppHost.csproj
+++ b/AspireAppWithAutomation/AspireAppWithAutomation.AppHost/AspireAppWithAutomation.AppHost.csproj
@@ -5,7 +5,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsAspireHost>true</IsAspireHost>
     </PropertyGroup>
 
     <ItemGroup>

--- a/AspireAppWithAutomation/AspireAppWithAutomation.ServiceDefaults/AspireAppWithAutomation.ServiceDefaults.csproj
+++ b/AspireAppWithAutomation/AspireAppWithAutomation.ServiceDefaults/AspireAppWithAutomation.ServiceDefaults.csproj
@@ -5,7 +5,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsAspireSharedProject>true</IsAspireSharedProject>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Issue
GitHub Actions workflow failing with Aspire Workload deprecation error:
```
error NETSDK1228: Aspire Workload has been deprecated
```

## What Changed
- Removed IsAspireHost property from AppHost project
- Removed IsAspireSharedProject property from ServiceDefaults project

## Why
Microsoft deprecated the Aspire Workload in favor of shipping Aspire via NuGet packages.

**Reference:** https://aka.ms/aspire/update-to-sdk

Fixes all 10 recent CI failures.