### PR TITLE
Fix CI: replace UseServiceDiscovery() with AddServiceDiscovery()

### DIFF
--- a/AspireAppWithAutomation/AspireAppWithAutomation.ServiceDefaults/Extensions.cs
+++ b/AspireAppWithAutomation/AspireAppWithAutomation.ServiceDefaults/Extensions.cs
@@ -26,7 +26,7 @@ public static class Extensions
             http.AddStandardResilienceHandler();
 
             // Turn on service discovery by default
-            http.UseServiceDiscovery();
+            http.AddServiceDiscovery();
         });
 
         return builder;


### PR DESCRIPTION
## Summary
- The `Microsoft.Extensions.ServiceDiscovery` 10.4.0 package renamed the `IHttpClientBuilder` extension method from `UseServiceDiscovery()` to `AddServiceDiscovery()`, causing the CI build to fail.
- Replaced the single call in `Extensions.cs` line 29 to use the new API name.

## Test plan
- [x] Verified the `ServiceDefaults` project builds successfully with zero errors and zero warnings.